### PR TITLE
Fix typos, JS bug and add basic tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# My Web App
+
+This is a small Flask application demonstrating a personal page with work experience entries.
+
+## Running Tests
+
+Install dependencies (Flask and pytest) then run:
+
+```bash
+pytest
+```
+

--- a/Static/map1.js
+++ b/Static/map1.js
@@ -24,10 +24,11 @@ var selectedIndex =-1;
             date: daTe,
             description: descriPtion}
 		console.log(selectedIndex);
-		if (selectedIndex===-1) {
-		   formarry.push(formObj);
-		   prepareTableCell(workPlace,daTe,descriPtion);
-	    }else {
+                if (selectedIndex===-1) {
+                   formarry.push(formObj);
+                   var newIndex = formarry.length - 1;
+                   prepareTableCell(workPlace, daTe, descriPtion, newIndex);
+            }else {
 		    formarry.splice(selectedIndex, 1, formObj);
 
 		}

--- a/template/base.html
+++ b/template/base.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/x-icon" href="{{ url_for('static',filename='python.png')}}" />
     <meta name="description" content="This short description describes my website.">
 
-    <!--add link to ccs file-->
+    <!--add link to css file-->
     <link href="{{ url_for('static',filename='my_styless.css')}}" rel="stylesheet">
 </head>
 {% block content %}{% endblock %}

--- a/template/main_view.html
+++ b/template/main_view.html
@@ -4,7 +4,7 @@
 <nav class="navbar">
 <div>
     <a href="https://www.linkedin.com/in/lyudmil-karaivanov-8b812160/"  target="_blank"><strong><i>My linkedin profile</i></strong></a>
-    <a href="http://127.0.0.1:5000/work_data"><strong><i>My work expiriance</i></strong></a>
+    <a href="http://127.0.0.1:5000/work_data"><strong><i>My work experience</i></strong></a>
 </div>
 </nav>
 <div id="ql2">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,20 @@
+import pytest
+
+from my_web import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_home_route(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b'My work experience' in response.data or b'my work experience' in response.data
+
+def test_work_data_route(client):
+    response = client.get('/work_data')
+    assert response.status_code == 200
+    # check for table headings or other unique text
+    assert b'Work Place' in response.data


### PR DESCRIPTION
## Summary
- fix navigation and base template typos
- correct index used when adding a new row in the JS code
- add simple Flask route tests
- document how to run tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683f3d40b808832382a450a86db60c07